### PR TITLE
Sumo to mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ bower_components
 wwwroot
 src/Hudl.BugBounty.WebApp/Scripts/**/*.js
 typings
+env/
+credentials.json
+.idea/

--- a/src/python/dictionary.dic
+++ b/src/python/dictionary.dic
@@ -1,0 +1,4 @@
+hudl
+mongo
+sourcecategory
+timeslice

--- a/src/python/get_sumo_results.py
+++ b/src/python/get_sumo_results.py
@@ -1,0 +1,31 @@
+import json
+import requests
+
+# https://github.com/SumoLogic/sumo-api-doc/wiki/Search-API#search
+# q (query) is required
+# from is optional, defaults to 15 minutes ago
+# to is optional, defaults to now
+# tz is optional, defaults to UTC
+# format is optional, default to json
+
+credentials_json = json.loads(open('credentials.json', 'r').read())
+access_id = credentials_json.get('access-id')
+access_key = credentials_json.get('access-key')
+
+sumo_base_url = 'https://api.us2.sumologic.com/api/v1/logs/search'
+query = '_index=app_hudl error ' \
+        '| where signature != "" ' \
+        '| timeslice by 5m ' \
+        '| fields signature, _sourceCategory, _timeslice ' \
+        '| count by signature, _timeslice, _sourceCategory' \
+        '| sort by signature asc'
+from_field = '2016-03-08T23:00:00'
+to = '2016-03-09T01:00:00'
+tz = 'America/Chicago'
+full_url = sumo_base_url + '?q=' + query + '&from=' + from_field + '&to=' + to + '&tz=' + tz
+
+r = requests.get(full_url, auth=(access_id, access_key))
+print('status code', r.status_code)
+
+output_file = open('sumo-output.json', 'w')
+output_file.write(r.text)

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,0 +1,2 @@
+pymongo==3.2.1
+requests==2.9.1

--- a/src/python/sumo-output.json
+++ b/src/python/sumo-output.json
@@ -1,0 +1,3722 @@
+[
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-115323938"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-115323938"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1248092168"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1272753971"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-128580823"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-128580823"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1302308837"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-138374262"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1401196278"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1439168998"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1439168998"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1468015271"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1468015271"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1468015271"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1468015271"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1565977495"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1596172789"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1674398057"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1674398057"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1674398057"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1674398057"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1821249731"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1918262262"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1971642365"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-1971642365"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-2043679536"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-2043679536"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-2043679536"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-2053910718"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-342252329"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-342252329"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-511154853"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-535815897"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-581949937"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-581949937"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-585150009"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-613502728"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "-844793881"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "0067bd64"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "0067bd64"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "0067bd64"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "0067bd64"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "02e19ecd"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "02e19ecd"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "02e19ecd"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "04ec4c17"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10109344"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10182309"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10256944"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10256944"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10312826"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10353481"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10476772"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10476772"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 9,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 7,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10732224"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10788684"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10859454"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10906243"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "10969085"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "11126172"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "11674309"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "11674309"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "11674309"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "11674309"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "11796261"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12146383"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12146383"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12252490"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12453400"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12453400"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12459801"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12459801"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "12703299"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "13266853"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "13266853"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "13755759"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "14297926"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "14297926"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "14477f9c"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "14568956"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "14954342"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "15566607"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "15566607"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "15678851"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "15678851"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "15770880"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "16360071"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "16656733"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "16851188"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "16851188"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "16b25fb3"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "16b48ec1"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "16b48ec1"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17389524"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17389524"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17389524"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17389524"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17389524"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17389524"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17625047"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17625047"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17717662"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17717662"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17801710"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "17801710"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18500878"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "18571259"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19224639"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19287622"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19349588"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19349588"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19349588"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19349588"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19349588"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19414856"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19596525"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19603902"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19603902"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19603902"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19603902"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19642833"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19683095"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19683095"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19683095"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19706830"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "197cfcc6"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "19899324"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "1a4829b5"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "1b9ec04b"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "1dca19bc"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 12,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "1e20ca76"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 18,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 18,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 16,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 16,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 12,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 11,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 16,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 12,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 18,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 16,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 11,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 12,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 16,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20164382"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20321006"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20344930"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20344930"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20344930"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20344930"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20375639"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20375639"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20375639"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "20936022"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "21065118"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "21098983"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "22620397"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "22620397"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "25c6b3a6"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "25c6b3a6"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "25c6b3a6"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "25c6b3a6"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "25c6b3a6"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "28890747"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "28890747"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "305e0e90"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "33893930"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "33893930"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "33893930"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "34066302"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "38248062"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "39928985"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3a920a69"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 13,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 17,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 15,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 14,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "3baa5a99"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "3fa40f82"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_push",
+    "signature" : "439f56e8"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "45244124"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "45244124"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "45244124"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "45244124"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 9,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "45bb83fb"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "46008066"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "460b4b2c"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "47015850"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "487374de"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49258492"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49258492"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49258492"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49258492"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49258492"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49258492"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49541556"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49586823"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49586823"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49586823"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "49592861"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50676987"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 76,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 107,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 101,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 77,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 76,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 104,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 79,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 103,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 107,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 81,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 113,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 111,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 123,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 75,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 117,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 77,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 118,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 106,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 81,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 77,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 75,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 82,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 109,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 75,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "50846811"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "51167790"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "51167790"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "51325db8"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 8,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55149048"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55374681"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55374681"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "55374681"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 12,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "556e365c"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "556e365c"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_jobs",
+    "signature" : "5b4a28bd"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "5b958a01"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "5d9d05b7"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "5ec459e0"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "5ec459e0"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63071141"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63071141"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63071141"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63071141"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63217188"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63622043"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63622043"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "63622043"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "65561146"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "65578532"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "668609fd"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "66a47fc7"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "68015768"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "6bf33ead"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "6fcc2c82"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "71246622"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "72380557"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "752c041c"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "752c041c"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "75566505"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "75566505"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78615415"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78854160"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "78e15e24"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "7b7c6b9d"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "7d6152f6"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "7deefc68"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "80575914"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "80575914"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "80575914"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "84603182"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "88291878"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "88291878"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "88291878"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "88291878"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "89863942"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "8a09dabe"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 7,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 9,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 7,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90027314"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "90398837"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "92c2164e"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "93548164"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "96357684"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "96357684"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "971636b4"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_statistics",
+    "signature" : "97eb5451"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "98286960"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "98286960"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 7,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "98286960"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9829a2cc"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "9b53e2fc"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9c81adde"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9c81adde"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9c81adde"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9c81adde"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9c81adde"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "9c81adde"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 5,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_highlights",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_profiles",
+    "signature" : "9f7b80f8"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "a08f7ac0"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "a08f7ac0"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "a08f7ac0"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "a08f7ac0"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "a10104f9"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "a1f5022a"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "a34f42dc"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "a6e9cd20"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_getpaid",
+    "signature" : "a9fa860c"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "ab0fc95a"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "ab0fc95a"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedproducer",
+    "signature" : "ad18ced1"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 11,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "aeaa5741"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b145588c"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b145588c"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b145588c"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b7bfd21c"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b7bfd21c"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b7bfd21c"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "b7bfd21c"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "c29ed7c5"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "c3d8d3c9"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "c7e92acb"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "c7e92acb"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "c8d091f9"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "cc24c38d"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "cc24c38d"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 8,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d0addfd9"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "d4f387ac"
+  },
+  {
+    "_timeslice" : "1457500800000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "d4f387ac"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_feedconsumer",
+    "signature" : "d4f387ac"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 109,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 110,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 110,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 111,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 107,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 52,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 109,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 107,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 110,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 103,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 111,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 110,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d507266c"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "d5ad80cb"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_teams",
+    "signature" : "d7b62a39"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_jobs",
+    "signature" : "da9c10f1"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "dc29d0d5"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "dc29d0d5"
+  },
+  {
+    "_timeslice" : "1457501400000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "dc29d0d5"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 4,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "dc29d0d5"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_recruit",
+    "signature" : "dc29d0d5"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "e5fd263b"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "e5fd263b"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_videoediting",
+    "signature" : "e5fd263b"
+  },
+  {
+    "_timeslice" : "1457502900000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "e71f3741"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 6,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "e71f3741"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 34,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 29,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 36,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457503800000",
+    "_count" : 36,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 34,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457506500000",
+    "_count" : 33,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 35,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457505600000",
+    "_count" : 36,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 10,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 35,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 35,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457505900000",
+    "_count" : 34,
+    "_sourcecategory" : "app_hudl_queuedservices",
+    "signature" : "f1386cdb"
+  },
+  {
+    "_timeslice" : "1457503200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "f6e265ad"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "f6e265ad"
+  },
+  {
+    "_timeslice" : "1457501700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "f6e265ad"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "f6e265ad"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "f6e265ad"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "f6e265ad"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 2,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "faf57f95"
+  },
+  {
+    "_timeslice" : "1457506200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "faf57f95"
+  },
+  {
+    "_timeslice" : "1457499900000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "faf57f95"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "faf57f95"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457505300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457500200000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457500500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457504100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457504700000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 3,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457501100000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457502300000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457505000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457504400000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_monolith",
+    "signature" : "fb008b51"
+  },
+  {
+    "_timeslice" : "1457499600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "ff8347bc"
+  },
+  {
+    "_timeslice" : "1457502600000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "ff8347bc"
+  },
+  {
+    "_timeslice" : "1457503500000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "ff8347bc"
+  },
+  {
+    "_timeslice" : "1457502000000",
+    "_count" : 1,
+    "_sourcecategory" : "app_hudl_web_leroy",
+    "signature" : "ff8347bc"
+  }
+]

--- a/src/python/update_mongo_db.py
+++ b/src/python/update_mongo_db.py
@@ -1,0 +1,57 @@
+from pymongo import MongoClient
+import datetime
+import json
+
+signature = 'signature'
+
+client = MongoClient('mongodb://s-bountyhunt-mongo-rs1-use1c-01.external.app.staghudl.com:27017')
+db = client.bounty
+errors = db.errors
+
+sumo_data = json.loads(open('sumo-output.json', 'r').read())
+for entry in sumo_data:
+    # entry_time produces a datetime, with milliseconds truncated
+    # entry_date produces a datetime representing midnight (morning) of the entry_time
+    # both are in UTC, so they include offset information
+    # e.g. Mongo will show 2016-03-09T18:00:00.000-0600 for central time
+
+    entry_time = datetime.datetime.fromtimestamp(int(entry['_timeslice']) / 1000)
+    entry_date = datetime.datetime(entry_time.year, entry_time.month, entry_time.day)
+
+    existing_entry = errors.find_one({signature: entry[signature]})
+
+    if existing_entry is not None:
+        print(entry[signature] + ' already exists, updating frequency')
+
+        hasDate = False
+        frequency = existing_entry['frequency']
+        for freq in frequency:
+            if str(freq['date']) == str(entry_date):
+                print(entry[signature] + ' frequency had date, updating count')
+                hasDate = True
+                freq['count'] += entry['_count']
+
+        if hasDate is False:
+            print(entry[signature] + ' frequency did not have date, adding date')
+            frequency.append({
+                'date': entry_date,
+                'count': entry['_count']
+            })
+
+        errors.update_one({'_id': existing_entry['_id']},
+                          {'$set': {'frequency': frequency}})
+
+    else:
+        print(entry[signature] + ' is new, adding it')
+        mongo_entry = {
+            signature: entry[signature],
+            'service': entry['_sourcecategory'],
+            'firstOccurrence': entry_time,
+            'frequency': [
+                {
+                    'date': datetime.datetime(entry_time.year, entry_time.month, entry_time.day),
+                    'count': entry['_count']
+                }
+            ]
+        }
+        errors.insert(mongo_entry)


### PR DESCRIPTION
A couple of relatively naive Python scripts to:
- Hit the SumoLogic API and save the results to a json file
- Read a json file, parse the results and save in MongoDB

Uncommitted, but you'll need a `credentials.json` file in the same directory. This will be of the following format:

```
{
  "access-id": "my-public-access-id",
  "access-key": "very-long-secret-access-key"
}
```

You can generate an access-id and access-key for yourself in SumoLogic's preferences menu.

Other notes:
- The dictionary is just a convenience for PyCharm so that it recognizes Hudl-specific words.
- Running it for more than a couple hour's worth of logs isn't recommended -- it starts taking a really long time.